### PR TITLE
Adds a safeguard to prevent loading images larger than the GPU max texture size.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,7 @@ dependencies = [
  "jpegxl-rs",
  "lcms2",
  "notify",
+ "pollster",
  "regex",
  "rfd",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,11 +2033,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpegxl-src"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c328aa9d824459bfb9aef47b8b3defa126df1bbd6fd3a1e59e703911d6dd00"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "jpegxl-sys"
 version = "0.11.2+libjxl-0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdaef0388e8220dc89a4ab47f92f942b68dfc237fa2dd3c3881948c5d88ce2f0"
 dependencies = [
+ "jpegxl-src",
  "pkg-config",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tempfile = "3.22.0"
 tracing-subscriber = { version = "0.3", default-features = true }
 tracing = "0.1.41"
 itertools = "0.14.0"
+pollster = "0.4.0"
 
 [profile.dev.package.image]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ fast_image_resize = { version = "5.1.4" }
 notify = "8.0.0"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 uuid = { version = "1.0", features = ["v4"] }
-jpegxl-rs = "0.11.2"
+jpegxl-rs = { version = "0.11.2", features = ["vendored"] }
 tempfile = "3.22.0"
 tracing-subscriber = { version = "0.3", default-features = true }
 tracing = "0.1.41"

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::{
     perf_metrics::PerfMetrics,
     tree, utils, VALID_EXTENSIONS,
 };
-use crate::{FRAME_MEMORY_KEY, WORKER_MESSAGE_MEMORY_KEY};
+use crate::{FRAME_MEMORY_KEY, TWO_DIM_TEXTURE_LIMIT_MEMORY_KEY, WORKER_MESSAGE_MEMORY_KEY};
 use eframe::egui::{self, Id, KeyboardShortcut, RichText};
 use eframe::Frame;
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -86,6 +86,15 @@ impl App {
                 tracing::info!("Failure initiating db -> {e}");
             }
         };
+
+        cc.egui_ctx.memory_mut(|mem| {
+            if let Some(wgpu_render_state) = cc.wgpu_render_state.clone() {
+                mem.data.insert_temp(
+                    Id::new(TWO_DIM_TEXTURE_LIMIT_MEMORY_KEY),
+                    wgpu_render_state.adapter.limits().max_texture_dimension_2d,
+                );
+            }
+        });
 
         let base_path = Self::get_base_path(&img_paths);
         let worker = Arc::new(worker);

--- a/src/image.rs
+++ b/src/image.rs
@@ -111,7 +111,7 @@ impl Image {
             );
             now = Instant::now();
 
-            let image_size = set_image_size(image_size, &ctx, image_size);
+            let image_size = set_image_size(image_size, &ctx, image.width().max(image.height()));
 
             if image_size.is_some() {
                 image = Self::resize(image, image_size);
@@ -519,17 +519,17 @@ pub fn extract_preview_from_raw_file(path: &Path) -> Option<Vec<u8>> {
 pub fn set_image_size(
     desired_size: Option<u32>,
     ctx: &egui::Context,
-    image_largest_size: Option<u32>,
+    image_largest_size: u32,
 ) -> Option<u32> {
     let limit: Option<u32> = ctx.memory(|x| {
         x.data
             .get_temp::<u32>(egui::Id::new(TWO_DIM_TEXTURE_LIMIT_MEMORY_KEY))
     });
 
-    match (desired_size, limit, image_largest_size) {
-        (Some(desired), Some(max), _) => Some(desired.min(max)),
-        (Some(desired), None, _) => Some(desired),
-        (None, Some(max), Some(image_largest_size)) => {
+    match (desired_size, limit) {
+        (Some(desired), Some(max)) => Some(desired.min(max)),
+        (Some(desired), None) => Some(desired),
+        (None, Some(max)) => {
             if image_largest_size > max {
                 Some(max)
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ pub const SKIP_ORIENT_EXTENSIONS: &[&str] = &[JXL_EXTENSION];
 
 pub const WORKER_MESSAGE_MEMORY_KEY: &str = "worker-message";
 pub const FRAME_MEMORY_KEY: &str = "frame-memory";
+pub const TWO_DIM_TEXTURE_LIMIT_MEMORY_KEY: &str = "2d-texture-limit";
 
 pub fn no_icon(
     _ui: &egui::Ui,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 use avis_imgv::app::App;
 use avis_imgv::db::Db;
 use eframe::egui_wgpu::{WgpuConfiguration, WgpuSetup, WgpuSetupCreateNew};
-use eframe::wgpu::{ExperimentalFeatures, Limits};
-use eframe::{wgpu, NativeOptions};
+use eframe::{
+    wgpu::{self},
+    NativeOptions,
+};
 use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
For now when trying to load an image with a texture larger than the maximum supported by the GPU, we will downscale the image to fit whole in the texture buffer.

In the future a tiling approach might be better, to be able to zoom in and see more detail, essentially the image in full res