### PR TITLE
Small improvements for install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,24 +12,24 @@ fi
 
 echo "Installing"
 
-if ! install -C -D -t $HOME/.local/bin/ ./target/release/avis-imgv; then
+if ! install -C -D -t "$HOME/.local/bin/" ./target/release/avis-imgv; then
   echo "Installation failed -> exiting"
 fi
 
 echo "Installation complete"
 
-applications_dir=$HOME/.local/share/applications
+applications_dir="$HOME/.local/share/applications"
 
-mkdir -p $applications_dir
+mkdir -p "$applications_dir"
 
-if [ ! -f $applications_dir/avis-imgv.desktop ]; then
+if [ ! -f "$applications_dir/avis-imgv.desktop" ]; then
   echo "[Desktop Entry]
 Exec=$HOME/.local/bin/avis-imgv
 MimeType=image/png;image/jpeg;image/jpg;image/webp;
 Name=Avis Image Viewer
 NoDisplay=false
-Type=Application" >$applications_dir/avis-imgv.desktop
+Type=Application" > "$applications_dir/avis-imgv.desktop"
 
   echo "Updating desktop database"
-  update-desktop-database -v $applications_dir
+  update-desktop-database -v "$applications_dir"
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if ! which cmake >/dev/null 2>&1; then
   echo "Please install cmake"
   exit


### PR DESCRIPTION
Hello! I wanted to try out this crate since it looked cool, and after checking the `install.sh` script, the linter I use for bash (shellcheck) complained about a few things. Mostly missing double quotes.

Also, since I use fish shell instead of bash, I found it useful to add a shebang to the beginning of that script so in can simply run `./install.sh` instead of `bash install.sh`.

As you say in your README, there are probably some ways for improving the script even further. Maybe adding support for uninstallation? Apart from that, I'm sure that an LLM could provide some basic tips.

In any case, feel free to change whatever you want from this PR, partly because I don't think I'll have the time to check GitHub very often.